### PR TITLE
Fix torch.compile for jagged nested tensors created inside compiled functions

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -3749,8 +3749,6 @@ class GraphModule(torch.nn.Module):
         values = torch.randn(10, 5).requires_grad_(True)
         self._validate_compile(fn, arg_fn=lambda: (values,))
 
-    # AssertionError: s2 (could be from ['<ephemeral: intermediate_offsets_or_lengths>',
-    @unittest.expectedFailure
     def test_in_graph_construction_from_intermediate_5(self):
         # non-shared intermediate
         def fn(values):
@@ -4183,6 +4181,68 @@ Eq(s20, s77)""",
     @unittest.expectedFailure
     def test_subclass_dense_subclass_dense_view(self):
         self._input_view_test("subclass_dense_subclass_dense")
+
+    def test_jagged_nested_tensor_in_graph_creation_from_regular_tensor(self):
+        """Test creating jagged nested tensor inside compile from regular input (issue #168307)"""
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def f(x):
+            return torch.nested.as_nested_tensor(x, layout=torch.jagged)
+
+        x = torch.randn(3, 4, 5)
+        result = f(x)
+        self.assertEqual(result.size(0), 3)
+
+    def test_jagged_nested_tensor_expand_and_convert(self):
+        """Test expanding tensor and converting to jagged nested tensor inside compile (issue #168307)"""
+
+        class Model(torch.nn.Module):
+            def __init__(self, seq_len, dim):
+                super().__init__()
+                self.register_buffer("i", torch.randn(1, seq_len, dim))
+
+            def forward(self, x):
+                batch_size = x.shape[0]
+                expanded_i = self.i.expand(batch_size, -1, -1)
+                nested_i = torch.nested.as_nested_tensor(
+                    expanded_i, layout=torch.jagged
+                )
+                return nested_i
+
+        model = Model(seq_len=10, dim=4)
+        compiled_model = torch.compile(model, backend="eager", fullgraph=True)
+        x = torch.randn(2, 10, 4)
+        result = compiled_model(x)
+        self.assertEqual(result.size(0), 2)
+
+    def test_jagged_nested_tensor_input_and_in_graph_creation(self):
+        """Test nested tensor input with additional nested tensor created inside compile (issue #168307)"""
+
+        class Model(torch.nn.Module):
+            def __init__(self, seq_len, dim):
+                super().__init__()
+                self.register_buffer("weight", torch.randn(1, seq_len, dim))
+
+            def forward(self, x):
+                # x is already a nested tensor input
+                # Create another nested tensor inside the graph
+                batch_size = x.size(0)
+                expanded_weight = self.weight.expand(batch_size, -1, -1)
+                weight_nested = torch.nested.as_nested_tensor(
+                    expanded_weight, layout=torch.jagged
+                )
+                # Operate on both nested tensors
+                return x.values() + weight_nested.values()
+
+        model = Model(seq_len=10, dim=4)
+        compiled_model = torch.compile(model, backend="eager", fullgraph=True)
+
+        # Create nested tensor input
+        tensors = [torch.randn(10, 4) for _ in range(3)]
+        x = torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
+
+        result = compiled_model(x)
+        self.assertEqual(result.shape, x.values().shape)
 
 
 instantiate_parametrized_tests(TestNestedTensor)

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5896,6 +5896,12 @@ class ShapeEnv:
             if expr in issued:
                 return
 
+            # Skip guards that involve symbols with only ephemeral sources.
+            # These symbols are created inside the graph (e.g., nested int symbols
+            # from jagged nested tensors) and cannot be guarded on.
+            if any(s in symbols_with_only_ephemeral_sources for s in expr.free_symbols):
+                return
+
             issued.add(expr)
 
             try:
@@ -5944,6 +5950,25 @@ class ShapeEnv:
             except Exception:
                 self.log.warning("Failing guard allocated at %s", guard.sloc)
                 raise
+
+        # Ensure all symbols that may appear in guards have sources from var_to_sources.
+        # This is needed for symbols created inside the graph (e.g., nested int symbols
+        # from jagged nested tensors) that aren't tracked via track_symint().
+        # Only use non-ephemeral sources since ephemeral sources cannot be guarded on.
+        # Track symbols that have only ephemeral sources so we can skip guards for them.
+        symbols_with_only_ephemeral_sources: set[sympy.Symbol] = set()
+        for guard in guards if guards is not None else self.guards:
+            for symbol in guard.expr.free_symbols:
+                if symbol not in symbol_to_source or not symbol_to_source[symbol]:
+                    if symbol in self.var_to_sources:
+                        non_ephemeral = [
+                            s for s in self.var_to_sources[symbol] if not s.is_ephemeral()
+                        ]
+                        if non_ephemeral:
+                            symbol_to_source[symbol] = non_ephemeral
+                        elif self.var_to_sources[symbol]:
+                            # All sources are ephemeral - mark for skipping
+                            symbols_with_only_ephemeral_sources.add(symbol)
 
         # First, issue all guards.
         # This removes all the checks that follow from bounds

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -5898,8 +5898,10 @@ class ShapeEnv:
 
             # Skip guards that involve symbols with only ephemeral sources.
             # These symbols are created inside the graph (e.g., nested int symbols
-            # from jagged nested tensors) and cannot be guarded on.
+            # from jagged nested tensors) and represent internal computations whose
+            # values are deterministic given the inputs. Guarding on them is redundant.
             if any(s in symbols_with_only_ephemeral_sources for s in expr.free_symbols):
+                self.log.debug("Skipping guard with ephemeral-only symbols: %s", expr)
                 return
 
             issued.add(expr)


### PR DESCRIPTION
## Summary

Fixes #168307

`torch.compile` fails when creating jagged nested tensors inside a compiled function with symbolic dimensions:

```python
@torch.compile
def forward(self, x):
    batch_size = x.shape[0]  # symbolic during compile
    expanded_i = self.i.expand(batch_size, -1, -1)
    nested_i = torch.nested.as_nested_tensor(expanded_i, layout=torch.jagged)  # FAILS
```

**Root Cause:** When `as_nested_tensor()` creates nested int symbols inside the compiled graph, they only have `EphemeralSource` (no input-derived source). During guard generation, these symbols appear in guard expressions but have no valid source for generating Python guard code, causing an `IndexError`.

**Fix:** Skip guards for symbols that have only ephemeral sources. These symbols represent internal computations that are deterministic given the inputs - if input guards pass, the internal values will be correct. This is safe because:
- Ephemeral symbols derive from input tensor shapes (already guarded)
- Their values are computed deterministically inside the graph
- Guarding on them is redundant

## Changes

- `torch/fx/experimental/symbolic_shapes.py`: Track symbols with only ephemeral sources and skip guards for them, with debug logging
- `test/dynamo/test_subclasses.py`: Add 3 regression tests, remove `@unittest.expectedFailure` from now-passing test

## Test plan

- [x] Original reproducer from issue #168307 now works
- [x] All 46 TestNestedTensor tests pass (2 expected failures for unrelated issues)
- [x] `test_in_graph_construction_from_intermediate_5` now passes (was expected failure)

```bash
python test/dynamo/test_subclasses.py TestNestedTensor -v
```